### PR TITLE
Improve error message if client fails to connect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ import YouTubeCastReceiver from "yt-cast-receiver";
 import { MpdPlayer } from "./player/MpdPlayer.js";
 import { MpdEventListener } from "./eventListener.js";
 
-
-
 const config = {
     host: process.env.MPD_HOST,
     port: process.env.MPD_PORT,
@@ -14,6 +12,7 @@ const config = {
 
 // We did not find a renderer with this location, so create one
 const player = new MpdPlayer(config);
+await player.initialize();
 
 const receiver = new YouTubeCastReceiver(player, {
     'device': {
@@ -24,24 +23,24 @@ const receiver = new YouTubeCastReceiver(player, {
 
 // When a sender connects
 receiver.on('senderConnect', (sender) => {
-    console.log(`Connected to ${sender.name}`);
-  });
+  console.log(`Connected to ${sender.name}`);
+});
   
-  // When a sender disconnects
-  receiver.on('senderDisconnect', (sender) => {
-    console.log(`Disconnected from ${sender.name}.`);
+// When a sender disconnects
+receiver.on('senderDisconnect', (sender) => {
+  console.log(`Disconnected from ${sender.name}.`);
+
+  // `yt-cast-receiver` supports multiple sender connections. Call
+  // `getConnectedSenders()` to obtain info about them.
+  console.log(`Remaining connected senders: ${receiver.getConnectedSenders().length}`);
+});
   
-    // `yt-cast-receiver` supports multiple sender connections. Call
-    // `getConnectedSenders()` to obtain info about them.
-    console.log(`Remaining connected senders: ${receiver.getConnectedSenders().length}`);
-  });
-  
-  // Start the receiver
-  try {
-    await receiver.start();
-  }
-  catch (error) {
-    console.log(`Failed to start receiver: ${error.message}`)
-  }
+// Start the receiver
+try {
+  await receiver.start();
+}
+catch (error) {
+  console.log(`Failed to start receiver: ${error.message}`)
+}
 
 const eventEmitter = new MpdEventListener(player, player.client);

--- a/src/player/MpdPlayer.ts
+++ b/src/player/MpdPlayer.ts
@@ -14,22 +14,21 @@ export class MpdPlayer extends Player {
     {
         // Call the Ytcr.Player constructor
         super();
-        (async () => {
-          
-            console.log("Creating new renderer: " + config.host);
-            this.httpServer = null;
-            // Instantiate the mediarender client
-            this.config = config
-            
-            this.client = await mpdapi.connect(config);
-            await this.client.api.playback.single('oneshot');
-            await this.client.api.playback.consume("0");
-            await this.client.api.queue.clear();
-            this.currentPlayStatus = 'stopped';
-            this.lastPlayBackCommand = 'NOTHING';
-        })();
-       
+        this.config = config;
+    }
 
+    public async initialize() {
+        console.log("Creating new renderer: " + this.config.host);
+        this.httpServer = null;
+        // Instantiate the mediarender client
+        
+        this.client = await mpdapi.connect(this.config);
+        await this.client.api.playback.single('oneshot');
+        await this.client.api.playback.consume("0");
+        await this.client.api.queue.clear();
+        this.currentPlayStatus = 'stopped';
+        this.lastPlayBackCommand = 'NOTHING';
+        console.log('Connected to renderer!');
     }
 
     protected async doPlay(video: Video, position: number): Promise<boolean> {


### PR DESCRIPTION
Updated initialization of the MPDPlayer class so that we wait until the connection to MPD succeeds before trying to start the YoutubeCastReceiver. In case of a connection issue with MPD, this makes it so that the error message provides useful info that the user can use to fix the issue.

Context: I was trying out this app in docker and had trouble getting it to work. The container was failing with very cryptic error messages (some turned out to be false positives from the yt-cast-receiver package, the releavant one was undefined field for `this.client` in the event listener).
After doing a local checkout of the repo and some troubleshooting, I realized that my issue was caused by ytm-mpd not being able to connect to MPD (due to a setup/config issue in my env). To figure this out, I updated the start up code so that we wait until the MPD connection succeds before doing anything else. 

I figured it would be useful to have these changes merged so that if others run into a similar issue, they can root cause & resolve it faster.

Also made some minor changes to fix indentation in index.ts